### PR TITLE
Add polymer-cli to before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   directories:
   - node_modules
 before_script:
-- npm install -g bower gulp-cli@1
+- npm install -g bower gulp-cli@1 polymer-cli
 - bower install
 - gulp lint-eslint
 script:


### PR DESCRIPTION
Without polymer-cli specified under `before_script`, users may run into errors when running tests on Travis CI. Adding polymer-cli to the npm script fixes this issue.


